### PR TITLE
Upgrade CMake to version 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.9)
 project(qt5-x11embed)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/ECM/find-modules")


### PR DESCRIPTION
This is necessary to avoid a CMake warning from qt5-x11embed when building LMMS with LTO enabled.

CMake versions under 3.5 are now out of support, and LMMS already uses CMake 3.9, so this is highly unlikely to break compatibility.

See https://github.com/LMMS/lmms/pull/7122