### PR TITLE
Avoid deprecated QFlags constructor

### DIFF
--- a/src/X11EmbedContainer.cpp
+++ b/src/X11EmbedContainer.cpp
@@ -419,7 +419,7 @@ QX11EmbedContainer *QX11EmbedContainerPrivate::activeContainer = 0;
 	Creates a QX11EmbedContainer object with the given \a parent.
 */
 QX11EmbedContainer::QX11EmbedContainer(QWidget *parent)
-	: QWidget(*new QX11EmbedContainerPrivate, parent, 0)
+	: QWidget(*new QX11EmbedContainerPrivate, parent, Qt::WindowFlags{})
 {
 	initAtoms();
 	Q_D(QX11EmbedContainer);


### PR DESCRIPTION
QFlags<E>(0) has been deprecated since Qt 5.15. This PR helps allow the upgrade to Qt 5.15 on Linux.