### PR TITLE
Bump minimum cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 project(qt5-x11embed)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/ECM/find-modules")


### PR DESCRIPTION
Systems that provide CMake 4 now won't compile this library, including some of the CIs that LMMS uses.

A blind fix is to raise the required version here to ensure compatibility with CMake 4.  If there's a better way to tackle this, I'd happily change this approach.

```
CMake Error at src/3rdparty/qt5-x11embed/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```